### PR TITLE
Add unit-tests for SplitEvaluator

### DIFF
--- a/plugin/sycl/tree/param.h
+++ b/plugin/sycl/tree/param.h
@@ -104,7 +104,8 @@ struct GradStats {
 
 /*!
  * \brief SYCL implementation of SplitEntryContainer for device compilation.
- *        Original structure cannot be used due to std::isinf usage, which is not supported
+ *        Original structure cannot be used due 'cat_bits' field of type std::vector<uint32_t>,
+ *        which is not device-copyable
  */
 template<typename GradientT>
 struct SplitEntryContainer {

--- a/plugin/sycl/tree/param.h
+++ b/plugin/sycl/tree/param.h
@@ -19,6 +19,8 @@
 #include "../src/tree/param.h"
 #pragma GCC diagnostic pop
 
+#include <CL/sycl.hpp>
+
 namespace xgboost {
 namespace sycl {
 namespace tree {

--- a/plugin/sycl/tree/param.h
+++ b/plugin/sycl/tree/param.h
@@ -91,44 +91,14 @@ struct GradStats {
     return os;
   }
 
-
   GradStats() {
   }
-
 
   template <typename GpairT>
   explicit GradStats(const GpairT &sum)
       : sum_grad(sum.GetGrad()), sum_hess(sum.GetHess()) {}
   explicit GradStats(const GradType grad, const GradType hess)
       : sum_grad(grad), sum_hess(hess) {}
-  /*!
-   * \brief accumulate statistics
-   * \param p the gradient pair
-   */
-  inline void Add(GradientPair p) { this->Add(p.GetGrad(), p.GetHess()); }
-
-
-  /*! \brief add statistics to the data */
-  inline void Add(const GradStats& b) {
-    sum_grad += b.sum_grad;
-    sum_hess += b.sum_hess;
-  }
-  /*! \brief same as add, reduce is used in All Reduce */
-  inline static void Reduce(GradStats& a, const GradStats& b) { // NOLINT(*)
-    a.Add(b);
-  }
-  /*! \brief set current value to a - b */
-  inline void SetSubstract(const GradStats& a, const GradStats& b) {
-    sum_grad = a.sum_grad - b.sum_grad;
-    sum_hess = a.sum_hess - b.sum_hess;
-  }
-  /*! \return whether the statistics is not used yet */
-  inline bool Empty() const { return sum_hess == 0.0; }
-  /*! \brief add statistics to the data */
-  inline void Add(GradType grad, GradType hess) {
-    sum_grad += grad;
-    sum_hess += hess;
-  }
 };
 
 

--- a/plugin/sycl/tree/split_evaluator.h
+++ b/plugin/sycl/tree/split_evaluator.h
@@ -12,6 +12,7 @@
 #include <limits>
 
 #include "param.h"
+#include "../data.h"
 
 #include "xgboost/tree_model.h"
 #include "xgboost/host_device_vector.h"
@@ -39,7 +40,7 @@ class TreeEvaluator {
 
   USMVector<GradType> lower_bounds_;
   USMVector<GradType> upper_bounds_;
-  USMVector<int32_t> monotone_;
+  USMVector<int> monotone_;
   TrainParam param_;
   ::sycl::queue qu_;
   bool has_constraint_;
@@ -47,20 +48,26 @@ class TreeEvaluator {
  public:
   void Reset(::sycl::queue qu, xgboost::tree::TrainParam const& p, bst_feature_t n_features) {
     qu_ = qu;
-    if (p.monotone_constraints.empty()) {
-      monotone_.Resize(&qu_, n_features, 0);
-      has_constraint_ = false;
-    } else {
+
+    has_constraint_ = false;
+    for (const auto& constraint : p.monotone_constraints) {
+      if (constraint != 0) has_constraint_ = true;
+    }
+
+    if (has_constraint_) {
       monotone_.Resize(&qu_, n_features, 0);
       qu_.memcpy(monotone_.Data(), p.monotone_constraints.data(),
-                 sizeof(int32_t) * p.monotone_constraints.size());
+                 sizeof(int) * p.monotone_constraints.size());
       qu_.wait();
 
-      lower_bounds_.Resize(&qu_, p.MaxNodes(), -std::numeric_limits<GradType>::max());
+      lower_bounds_.Resize(&qu_, p.MaxNodes(), std::numeric_limits<GradType>::lowest());
       upper_bounds_.Resize(&qu_, p.MaxNodes(), std::numeric_limits<GradType>::max());
-      has_constraint_ = true;
     }
     param_ = TrainParam(p);
+  }
+
+  bool HasConstraint() const {
+    return has_constraint_;
   }
 
   TreeEvaluator(::sycl::queue qu, xgboost::tree::TrainParam const& p, bst_feature_t n_features) {
@@ -78,13 +85,17 @@ class TreeEvaluator {
                         bst_feature_t fidx,
                         const GradStats<GradType>& left,
                         const GradStats<GradType>& right) const {
-      int constraint = constraints[fidx];
       const GradType negative_infinity = -std::numeric_limits<GradType>::infinity();
       GradType wleft = this->CalcWeight(nidx, left);
       GradType wright = this->CalcWeight(nidx, right);
 
       GradType gain = this->CalcGainGivenWeight(nidx, left, wleft) +
                     this->CalcGainGivenWeight(nidx, right, wright);
+      if (!has_constraint) {
+        return gain;
+      }
+
+      int constraint = constraints[fidx];
       if (constraint == 0) {
         return gain;
       } else if (constraint > 0) {

--- a/plugin/sycl/tree/split_evaluator.h
+++ b/plugin/sycl/tree/split_evaluator.h
@@ -51,7 +51,10 @@ class TreeEvaluator {
 
     has_constraint_ = false;
     for (const auto& constraint : p.monotone_constraints) {
-      if (constraint != 0) has_constraint_ = true;
+      if (constraint != 0) {
+          has_constraint_ = true;
+          break;
+      }
     }
 
     if (has_constraint_) {

--- a/plugin/sycl/tree/split_evaluator.h
+++ b/plugin/sycl/tree/split_evaluator.h
@@ -89,8 +89,8 @@ class TreeEvaluator {
       GradType wleft = this->CalcWeight(nidx, left);
       GradType wright = this->CalcWeight(nidx, right);
 
-      GradType gain = this->CalcGainGivenWeight(nidx, left, wleft) +
-                    this->CalcGainGivenWeight(nidx, right, wright);
+      GradType gain = this->CalcGainGivenWeight(nidx, left,  wleft) +
+                      this->CalcGainGivenWeight(nidx, right, wright);
       if (!has_constraint) {
         return gain;
       }
@@ -105,7 +105,7 @@ class TreeEvaluator {
       }
     }
 
-    inline GradType ThresholdL1(GradType w, GradType alpha) const {
+    inline static GradType ThresholdL1(GradType w, float alpha) {
       if (w > + alpha) {
         return w - alpha;
       }

--- a/tests/cpp/plugin/test_sycl_split_evaluator.cc
+++ b/tests/cpp/plugin/test_sycl_split_evaluator.cc
@@ -32,7 +32,87 @@ void BasicTestSplitEvaluator(const std::string& monotone_constraints, bool has_c
   auto qu = device_manager.GetQueue(DeviceOrd::SYCL_default());
 
   TreeEvaluator<GradientSumT> tree_evaluator(qu, param, n_columns);
-  ASSERT_EQ(tree_evaluator.HasConstraint(), has_constrains);
+  {
+    // Check correctness of has_constrains flag
+    ASSERT_EQ(tree_evaluator.HasConstraint(), has_constrains);
+  }
+
+  auto split_evaluator = tree_evaluator.GetEvaluator();
+  {
+    // Check if params were inititialised correctly
+    ASSERT_EQ(split_evaluator.param.min_child_weight, param.min_child_weight);
+    ASSERT_EQ(split_evaluator.param.reg_lambda, param.reg_lambda);
+    ASSERT_EQ(split_evaluator.param.reg_alpha, param.reg_alpha);
+    ASSERT_EQ(split_evaluator.param.max_delta_step, param.max_delta_step);
+  }
+}
+
+template<typename GradientSumT>
+void TestSplitEvaluator(const std::string& monotone_constraints) {
+  const size_t n_columns = 2;
+
+  xgboost::tree::TrainParam param;
+  param.UpdateAllowUnknown(Args{{"min_child_weight", "0"},
+                                {"reg_lambda", "0"},
+                                {"monotone_constraints", monotone_constraints}});
+
+  DeviceManager device_manager;
+  auto qu = device_manager.GetQueue(DeviceOrd::SYCL_default());
+
+  TreeEvaluator<GradientSumT> tree_evaluator(qu, param, n_columns);
+  auto split_evaluator = tree_evaluator.GetEvaluator();
+  {
+    // Test ThresholdL1
+    const GradientSumT alpha = 0.5;
+    {
+      const GradientSumT val = 0.0;
+      const auto trh = split_evaluator.ThresholdL1(val, alpha);
+      ASSERT_EQ(trh, 0.0);
+    }
+
+    {
+      const GradientSumT val = 1.0;
+      const auto trh = split_evaluator.ThresholdL1(val, alpha);
+      ASSERT_EQ(trh, val - alpha);
+    }
+
+    {
+      const GradientSumT val = -1.0;
+      const auto trh = split_evaluator.ThresholdL1(val, alpha);
+      ASSERT_EQ(trh, val + alpha);
+    }
+  }
+
+  {
+    tree_evaluator.AddSplit(0, 1, 2, 0, 0.3, 0.7);
+
+    GradStats<GradientSumT> left(0.1, 0.2);
+    GradStats<GradientSumT> right(0.3, 0.4);
+    bst_node_t nidx = 0;
+    bst_feature_t fidx = 0;
+
+    GradientSumT wleft  = split_evaluator.CalcWeight(nidx, left);
+    // wleft = -grad/hess = -0.1/0.2
+    ASSERT_EQ(round(wleft * 100), -50);
+    GradientSumT wright = split_evaluator.CalcWeight(nidx, right);
+    // wright = -grad/hess = -0.3/0.4
+    ASSERT_EQ(round(wright * 100), -75);
+
+    GradientSumT gweight_left = split_evaluator.CalcGainGivenWeight(nidx, left, wleft);
+    // gweight_left = left.grad**2 / left.hess = 0.1*0.1/0.2 = 0.05
+    ASSERT_EQ(round(gweight_left*100), 5);
+    // gweight_left = right.grad**2 / right.hess = 0.3*0.3/0.4 = 0.225
+    GradientSumT gweight_right = split_evaluator.CalcGainGivenWeight(nidx, right, wright);
+    ASSERT_EQ(round(gweight_right*1000), 225);
+
+    GradientSumT split_gain = split_evaluator.CalcSplitGain(nidx, fidx, left, right);
+    if (!tree_evaluator.HasConstraint()) {
+      ASSERT_EQ(split_gain, gweight_left + gweight_right);
+    } else {
+      // Parameters are chosen to have -inf here
+      ASSERT_EQ(split_gain, -std::numeric_limits<GradientSumT>::infinity());
+    }
+  }
 }
 
 TEST(SyclSplitEvaluator, BasicTest) {
@@ -45,6 +125,13 @@ TEST(SyclSplitEvaluator, BasicTest) {
   BasicTestSplitEvaluator<float>("(-1, -1)", true);
   BasicTestSplitEvaluator<float>("( 1, -1)", true);
   BasicTestSplitEvaluator<float>("(-1,  1)", true);
+}
+
+TEST(SyclSplitEvaluator, TestMath) {
+  // Without constraints
+  TestSplitEvaluator<float>("( 0,  0)");
+  // With constraints
+  TestSplitEvaluator<float>("( 1,  0)");
 }
 
 }  // namespace xgboost::sycl::tree

--- a/tests/cpp/plugin/test_sycl_split_evaluator.cc
+++ b/tests/cpp/plugin/test_sycl_split_evaluator.cc
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2020-2023 by XGBoost contributors
+ */
+#include <gtest/gtest.h>
+
+// #include <string>
+// #include <utility>
+#include <vector>
+// #include <numeric>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtautological-constant-compare"
+#pragma GCC diagnostic ignored "-W#pragma-messages"
+#include "../../../plugin/sycl/tree/split_evaluator.h"
+#pragma GCC diagnostic pop
+
+#include "../../../plugin/sycl/device_manager.h"
+#include "../helpers.h"
+
+namespace xgboost::sycl::tree {
+
+template<typename GradientSumT>
+void BasicTestSplitEvaluator(const std::string& monotone_constraints, bool has_constrains) {
+  const size_t n_columns = 2;
+
+  xgboost::tree::TrainParam param;
+  param.UpdateAllowUnknown(Args{{"min_child_weight", "0"},
+                                {"reg_lambda", "0"},
+                                {"monotone_constraints", monotone_constraints}});
+
+  DeviceManager device_manager;
+  auto qu = device_manager.GetQueue(DeviceOrd::SYCL_default());
+
+  TreeEvaluator<GradientSumT> tree_evaluator(qu, param, n_columns);
+  ASSERT_EQ(tree_evaluator.HasConstraint(), has_constrains);
+}
+
+TEST(SyclSplitEvaluator, BasicTest) {
+  BasicTestSplitEvaluator<float>("( 0,  0)", false);
+  BasicTestSplitEvaluator<float>("( 1,  0)", true);
+  BasicTestSplitEvaluator<float>("( 0,  1)", true);
+  BasicTestSplitEvaluator<float>("(-1,  0)", true);
+  BasicTestSplitEvaluator<float>("( 0, -1)", true);
+  BasicTestSplitEvaluator<float>("( 1,  1)", true);
+  BasicTestSplitEvaluator<float>("(-1, -1)", true);
+  BasicTestSplitEvaluator<float>("( 1, -1)", true);
+  BasicTestSplitEvaluator<float>("(-1,  1)", true);
+}
+
+}  // namespace xgboost::sycl::tree

--- a/tests/cpp/plugin/test_sycl_split_evaluator.cc
+++ b/tests/cpp/plugin/test_sycl_split_evaluator.cc
@@ -80,6 +80,7 @@ void TestSplitEvaluator(const std::string& monotone_constraints) {
   }
 
   {
+    constexpr float eps = 1e-8;
     tree_evaluator.AddSplit(0, 1, 2, 0, 0.3, 0.7);
 
     GradStats<GradientSumT> left(0.1, 0.2);
@@ -89,21 +90,21 @@ void TestSplitEvaluator(const std::string& monotone_constraints) {
 
     GradientSumT wleft  = split_evaluator.CalcWeight(nidx, left);
     // wleft = -grad/hess = -0.1/0.2
-    ASSERT_EQ(round(wleft * 100), -50);
+    EXPECT_NEAR(wleft, -0.5, eps);
     GradientSumT wright = split_evaluator.CalcWeight(nidx, right);
     // wright = -grad/hess = -0.3/0.4
-    ASSERT_EQ(round(wright * 100), -75);
+    EXPECT_NEAR(wright, -0.75, eps);
 
     GradientSumT gweight_left = split_evaluator.CalcGainGivenWeight(nidx, left, wleft);
     // gweight_left = left.grad**2 / left.hess = 0.1*0.1/0.2 = 0.05
-    ASSERT_EQ(round(gweight_left*100), 5);
+    EXPECT_NEAR(gweight_left, 0.05, eps);
     // gweight_left = right.grad**2 / right.hess = 0.3*0.3/0.4 = 0.225
     GradientSumT gweight_right = split_evaluator.CalcGainGivenWeight(nidx, right, wright);
-    ASSERT_EQ(round(gweight_right*1000), 225);
+    EXPECT_NEAR(gweight_right, 0.225, eps);
 
     GradientSumT split_gain = split_evaluator.CalcSplitGain(nidx, fidx, left, right);
     if (!tree_evaluator.HasConstraint()) {
-      ASSERT_EQ(split_gain, gweight_left + gweight_right);
+      EXPECT_NEAR(split_gain, gweight_left + gweight_right, eps);
     } else {
       // Parameters are chosen to have -inf here
       ASSERT_EQ(split_gain, -std::numeric_limits<GradientSumT>::infinity());

--- a/tests/cpp/plugin/test_sycl_split_evaluator.cc
+++ b/tests/cpp/plugin/test_sycl_split_evaluator.cc
@@ -1,12 +1,8 @@
 /**
- * Copyright 2020-2023 by XGBoost contributors
+ * Copyright 2020-2024 by XGBoost contributors
  */
 #include <gtest/gtest.h>
-
-// #include <string>
-// #include <utility>
 #include <vector>
-// #include <numeric>
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wtautological-constant-compare"


### PR DESCRIPTION
1. Add unit-tests for SplitEvaluator. 
2. Simplify calculations without monotonic constraints.