### PR TITLE
Fix sampling for fp32 devices

### DIFF
--- a/plugin/sycl/tree/hist_updater.cc
+++ b/plugin/sycl/tree/hist_updater.cc
@@ -472,7 +472,6 @@ void HistUpdater<GradientSumT>::InitSampling(
         });
       });
     } else {
-      LOG(FATAL) << "Fail";
       // Use oneDPL uniform for better perf, as far as bernoulli_distribution uses fp64
       event = qu_.submit([&](::sycl::handler& cgh) {
         auto flag_buf_acc  = flag_buf.get_access<::sycl::access::mode::read_write>(cgh);

--- a/plugin/sycl/tree/hist_updater.cc
+++ b/plugin/sycl/tree/hist_updater.cc
@@ -488,7 +488,7 @@ void HistUpdater<GradientSumT>::InitSampling(
             row_idx[num_samples_ref++] = i;
           }
         });
-      });      
+      });
     }
     /* After calling a destructor for flag_buf,  content will be copyed to num_samples */
   }

--- a/plugin/sycl/tree/hist_updater.cc
+++ b/plugin/sycl/tree/hist_updater.cc
@@ -453,7 +453,7 @@ void HistUpdater<GradientSumT>::InitSampling(
     * In this case the device doesn't have fp64 support, 
     * we generate bernoulli distributed random values from uniform distribution
     */
-    if (qu_.get_device().has(::sycl::aspect::fp64)) {
+    if (has_fp64_support_) {
       // Use oneDPL bernoulli_distribution for better perf
       event = qu_.submit([&](::sycl::handler& cgh) {
         auto flag_buf_acc  = flag_buf.get_access<::sycl::access::mode::read_write>(cgh);

--- a/plugin/sycl/tree/hist_updater.cc
+++ b/plugin/sycl/tree/hist_updater.cc
@@ -447,32 +447,50 @@ void HistUpdater<GradientSumT>::InitSampling(
     ::sycl::buffer<uint64_t, 1> flag_buf(&num_samples, 1);
     uint64_t seed = seed_;
     seed_ += num_rows;
-    event = qu_.submit([&](::sycl::handler& cgh) {
-      auto flag_buf_acc  = flag_buf.get_access<::sycl::access::mode::read_write>(cgh);
-      cgh.parallel_for<>(::sycl::range<1>(::sycl::range<1>(num_rows)),
-                                          [=](::sycl::item<1> pid) {
-        uint64_t i = pid.get_id(0);
 
-        // // Create minstd_rand engine
-        // oneapi::dpl::minstd_rand engine(seed, i);
-        // oneapi::dpl::bernoulli_distribution coin_flip(subsample);
+  /* 
+    * oneDLP bernoulli_distribution implicitly uses double.
+    * In this case the device doesn't have fp64 support, 
+    * we generate bernoulli distributed random values from uniform distribution
+    */
+    if (qu_.get_device().has(::sycl::aspect::fp64)) {
+      // Use oneDPL bernoulli_distribution for better perf
+      event = qu_.submit([&](::sycl::handler& cgh) {
+        auto flag_buf_acc  = flag_buf.get_access<::sycl::access::mode::read_write>(cgh);
+        cgh.parallel_for<>(::sycl::range<1>(::sycl::range<1>(num_rows)),
+                                            [=](::sycl::item<1> pid) {
+          uint64_t i = pid.get_id(0);
+          // Create minstd_rand engine
+          oneapi::dpl::minstd_rand engine(seed, i);
+          oneapi::dpl::bernoulli_distribution coin_flip(subsample);
+          auto bernoulli_rnd = coin_flip(engine);
 
-        // auto rnd = coin_flip(engine);
-
-        /* 
-         * oneDLP bernoulli_distribution implicitly uses double.
-         * We generate bernoulli distributed random values from uniform distribution
-         */
-        oneapi::dpl::minstd_rand engine(seed, i);
-        oneapi::dpl::uniform_real_distribution<float> distr;
-        const float rnd = distr(engine);
-        const bool bernoulli_rnd = rnd < subsample ? 1 : 0;
-        if (gpair_ptr[i].GetHess() >= 0.0f && bernoulli_rnd) {
-          AtomicRef<uint64_t> num_samples_ref(flag_buf_acc[0]);
-          row_idx[num_samples_ref++] = i;
-        }
+          if (gpair_ptr[i].GetHess() >= 0.0f && bernoulli_rnd) {
+            AtomicRef<uint64_t> num_samples_ref(flag_buf_acc[0]);
+            row_idx[num_samples_ref++] = i;
+          }
+        });
       });
-    });
+    } else {
+      LOG(FATAL) << "Fail";
+      // Use oneDPL uniform for better perf, as far as bernoulli_distribution uses fp64
+      event = qu_.submit([&](::sycl::handler& cgh) {
+        auto flag_buf_acc  = flag_buf.get_access<::sycl::access::mode::read_write>(cgh);
+        cgh.parallel_for<>(::sycl::range<1>(::sycl::range<1>(num_rows)),
+                                            [=](::sycl::item<1> pid) {
+          uint64_t i = pid.get_id(0);
+          oneapi::dpl::minstd_rand engine(seed, i);
+          oneapi::dpl::uniform_real_distribution<float> distr;
+          const float rnd = distr(engine);
+          const bool bernoulli_rnd = rnd < subsample ? 1 : 0;
+
+          if (gpair_ptr[i].GetHess() >= 0.0f && bernoulli_rnd) {
+            AtomicRef<uint64_t> num_samples_ref(flag_buf_acc[0]);
+            row_idx[num_samples_ref++] = i;
+          }
+        });
+      });      
+    }
     /* After calling a destructor for flag_buf,  content will be copyed to num_samples */
   }
 

--- a/plugin/sycl/tree/hist_updater.h
+++ b/plugin/sycl/tree/hist_updater.h
@@ -66,6 +66,7 @@ class HistUpdater {
     if (param.max_depth > 0) {
       snode_device_.Resize(&qu, 1u << (param.max_depth + 1));
     }
+    has_fp64_support_ = qu_.get_device().has(::sycl::aspect::fp64);
     const auto sub_group_sizes =
       qu_.get_device().get_info<::sycl::info::device::sub_group_sizes>();
     sub_group_size_ = sub_group_sizes.back();
@@ -211,6 +212,7 @@ class HistUpdater {
 
   //  --data fields--
   const Context* ctx_;
+  bool has_fp64_support_;
   size_t sub_group_size_;
   const xgboost::tree::TrainParam& param_;
   std::shared_ptr<xgboost::common::ColumnSampler> column_sampler_;


### PR DESCRIPTION
This PR fix sampling on devices without fp64 support, such as integrated GPU. oneDPL always uses double in Bernoulli distribution calculation. It makes impossible to use it on fp32-only devices.