### PR TITLE
Remove deprecated ext_intel_global_device_space

### DIFF
--- a/plugin/sycl/data.h
+++ b/plugin/sycl/data.h
@@ -30,7 +30,7 @@ template <typename T>
 using AtomicRef = ::sycl::atomic_ref<T,
                                     ::sycl::memory_order::relaxed,
                                     ::sycl::memory_scope::device,
-                                    ::sycl::access::address_space::ext_intel_global_device_space>;
+                                    ::sycl::access::address_space::global_space>;
 
 enum class MemoryType { shared, on_device};
 


### PR DESCRIPTION
ext_intel_global_device_space is removed from sycl::access::address_space by https://github.com/intel/llvm/issues/16929